### PR TITLE
Add image tag to docker build output

### DIFF
--- a/prefect_docker/projects/steps.py
+++ b/prefect_docker/projects/steps.py
@@ -19,9 +19,11 @@ class BuildDockerImageResult(TypedDict):
 
     Attributes:
         image_name: The name and tag of the built image.
+        image_tag: The tag of the built image.
     """
 
     image_name: str
+    image_tag: str
 
 
 def build_docker_image(
@@ -135,4 +137,4 @@ def build_docker_image(
             finally:
                 client.api.remove_image(image=f"{image_name}:{tag}", noprune=True)
 
-    return {"image_name": f"{image_name}:{tag}"}
+    return {"image_name": f"{image_name}:{tag}", "image_tag": tag}

--- a/tests/projects/test_steps.py
+++ b/tests/projects/test_steps.py
@@ -119,6 +119,7 @@ def test_build_docker_image(
     result = build_docker_image(**kwargs)
 
     assert result["image_name"] == expected_image_name
+    assert result["image_tag"] == tag
 
     if dockerfile == "auto":
         auto_build = True


### PR DESCRIPTION
Adds `image_tag` to build step output; useful for versioning deployments.