### PR TITLE
Adds temporary `prefect` version guard

### DIFF
--- a/prefect_docker/worker.py
+++ b/prefect_docker/worker.py
@@ -31,16 +31,12 @@ import packaging.version
 import prefect
 from docker import DockerClient
 from docker.models.containers import Container
+from packaging import version
 from prefect.client.schemas import FlowRun
 from prefect.docker import (
     format_outlier_version_name,
     get_prefect_image_name,
     parse_image_tag,
-)
-from prefect.experimental.workers.base import (
-    BaseJobConfiguration,
-    BaseWorker,
-    BaseWorkerResult,
 )
 from prefect.server.schemas.core import Flow
 from prefect.server.schemas.responses import DeploymentResponse
@@ -49,6 +45,17 @@ from prefect.utilities.asyncutils import run_sync_in_worker_thread
 from pydantic import Field, validator
 from slugify import slugify
 from typing_extensions import Literal
+
+# TODO: Remove this after next prefect release
+if version.parse(prefect.__version__) <= version.parse("2.9.0"):
+    from prefect.experimental.workers.base import (
+        BaseJobConfiguration,
+        BaseWorker,
+        BaseWorkerResult,
+    )
+else:
+    from prefect.workers.base import BaseJobConfiguration, BaseWorker, BaseWorkerResult
+
 
 CONTAINER_LABELS = {
     "io.prefect.version": prefect.__version__,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 black
 flake8
+flaky
 interrogate
 isort
 mkdocs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-prefect>=2.0.0
+prefect>=2.9.0
 docker>=6.0.0

--- a/tests/projects/test_steps.py
+++ b/tests/projects/test_steps.py
@@ -161,6 +161,7 @@ def test_build_docker_image_raises_with_auto_and_existing_dockerfile():
         Path("Dockerfile").unlink()
 
 
+@pytest.mark.flaky(max_runs=3)
 def test_real_auto_dockerfile_build(docker_client_with_cleanup):
     try:
         result = build_docker_image(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -826,6 +826,7 @@ async def test_does_not_warn_about_gateway_if_not_using_linux(
     assert not call_extra_hosts
 
 
+@pytest.mark.flaky(max_runs=3)
 async def test_container_result(
     docker_client_with_cleanup: "DockerClient",
     flow_run,
@@ -843,6 +844,7 @@ async def test_container_result(
         assert container is not None
 
 
+@pytest.mark.flaky(max_runs=3)
 async def test_container_auto_remove(
     docker_client_with_cleanup: "DockerClient",
     flow_run,
@@ -864,6 +866,7 @@ async def test_container_auto_remove(
             docker_client_with_cleanup.containers.get(container_id)
 
 
+@pytest.mark.flaky(max_runs=3)
 async def test_container_metadata(
     docker_client_with_cleanup: "DockerClient",
     flow_run,
@@ -888,6 +891,7 @@ async def test_container_metadata(
         assert container.labels[key] == value
 
 
+@pytest.mark.flaky(max_runs=3)
 async def test_container_name_collision(
     docker_client_with_cleanup: "DockerClient",
     flow_run,
@@ -920,6 +924,7 @@ async def test_container_name_collision(
         assert created_container.name == base_name + "-1"
 
 
+@pytest.mark.flaky(max_runs=3)
 async def test_container_result_async(
     docker_client_with_cleanup: "DockerClient",
     flow_run,
@@ -987,6 +992,7 @@ async def test_logs_when_unexpected_docker_error(
     )
 
 
+@pytest.mark.flaky(max_runs=3)
 async def test_stream_container_logs_on_real_container(
     capsys, flow_run, default_docker_worker_job_configuration
 ):


### PR DESCRIPTION

Adds a temporary check for `prefect` version to ensure that worker-related classes are imported from the correct module.
