### PR TITLE
Error out on init if used with ephemeral API

### DIFF
--- a/prefect_docker/worker.py
+++ b/prefect_docker/worker.py
@@ -32,7 +32,7 @@ import prefect
 from docker import DockerClient
 from docker.models.containers import Container
 from packaging import version
-from prefect.client.orchestration import get_client, ServerType
+from prefect.client.orchestration import ServerType, get_client
 from prefect.client.schemas import FlowRun
 from prefect.docker import (
     format_outlier_version_name,
@@ -373,11 +373,12 @@ class DockerWorker(BaseWorker):
     type = "docker"
     job_configuration = DockerWorkerJobConfiguration
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    async def setup(self):
         self._client = get_client()
         if self._client.server_type == ServerType.EPHEMERAL:
             raise RuntimeError("Docker worker cannot be used with an ephemeral server.")
+
+        return await super().setup()
 
     async def run(
         self,

--- a/prefect_docker/worker.py
+++ b/prefect_docker/worker.py
@@ -32,6 +32,7 @@ import prefect
 from docker import DockerClient
 from docker.models.containers import Container
 from packaging import version
+from prefect.client.orchestration import get_client, ServerType
 from prefect.client.schemas import FlowRun
 from prefect.docker import (
     format_outlier_version_name,
@@ -371,6 +372,12 @@ class DockerWorker(BaseWorker):
 
     type = "docker"
     job_configuration = DockerWorkerJobConfiguration
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._client = get_client()
+        if self._client.server_type == ServerType.EPHEMERAL:
+            raise RuntimeError("Docker worker cannot be used with an ephemeral server.")
 
     async def run(
         self,


### PR DESCRIPTION
The Docker Worker and the Docker container must talk to the same DB in order for runs to execute properly; as a proxy for this, we can prevent the docker worker from running with an ephemeral API (technically speaking, it would work if the container and the submitting process share a DB connection string but I think until we hear of users operating that way this is the best UX).


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "Closes #<ISSUE_NUMBER>"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-docker/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-docker/blob/main/CHANGELOG.md)
