### PR TITLE
Adds `kill_infrastructure` method to `DockerWorker`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `kill_infrastructure` method on `DockerWorker` which stops containers for cancelled flow runs  - [#48](https://github.com/PrefectHQ/prefect-docker/pull/48)
+
 ### Changed
 
 ### Deprecated

--- a/prefect_docker/worker.py
+++ b/prefect_docker/worker.py
@@ -460,10 +460,7 @@ class DockerWorker(BaseWorker):
                 " found."
             )
 
-        try:
-            container.stop(timeout=grace_seconds)
-        except Exception:
-            raise
+        container.stop(timeout=grace_seconds)
 
     def _get_client(self):
         """Returns a docker client."""


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to prefect-docker 🎉!

We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Run `pre-commit install && pre-commit run --all` for linting.

Happy engineering!
-->

<!-- Include an overview here -->
Ports the ability to stops jobs for cancelled flow runs from the `DockerContainer` block.

Note this needs to wait until https://github.com/PrefectHQ/prefect/pull/9250 is released for release of `prefect-docker` and will require a bump of the minimum prefect version.


### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "Closes #<ISSUE_NUMBER>"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-docker/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-docker/blob/main/CHANGELOG.md)
