### PR TITLE
Adds ability to pass build kwargs into `build_docker_image`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Ability to pass build kwargs into `build_docker_image` - [#51](https://github.com/PrefectHQ/prefect-docker/pull/51)
+- `image_id` and `image` to `build_docker_image` output. image has the same contents as the current `image_name` - [#51](https://github.com/PrefectHQ/prefect-docker/pull/51)
+
 ### Changed
+
+- BREAKING: `image_name` updated to contain only the image name without the tag - [#51](https://github.com/PrefectHQ/prefect-docker/pull/51)
 
 ### Deprecated
 

--- a/prefect_docker/projects/steps.py
+++ b/prefect_docker/projects/steps.py
@@ -1,14 +1,35 @@
 """
 Prefect project steps for building and pushing Docker images.
+
+
+These steps can be used in a project's `prefect.yaml` file to define the default
+build steps for the entire project, or they can be used in a project's
+`deplyment.yaml` file to define the build step for a specific deployment.
+
+!!! example
+    Build a Docker image as part of a Prefect project deployment:
+    ```yaml
+    build:
+        - prefect_docker.projects.steps.build_docker_image:
+            requires: prefect-docker
+            image_name: repo-name/image-name
+            tag: dev
+    ```
 """
 import os
 import sys
 from pathlib import Path
 from typing import Dict, Optional
 
+import docker.errors
 import pendulum
 from docker.models.images import Image
-from prefect.docker import build_image, docker_client, get_prefect_image_name
+from prefect.docker import (
+    IMAGE_LABELS,
+    BuildError,
+    docker_client,
+    get_prefect_image_name,
+)
 from prefect.utilities.slugify import slugify
 from typing_extensions import TypedDict
 
@@ -18,20 +39,25 @@ class BuildDockerImageResult(TypedDict):
     The result of a `build_docker_image` step.
 
     Attributes:
-        image_name: The name and tag of the built image.
+        image_name: The name of the built image.
         image_tag: The tag of the built image.
+        image: The name and tag of the built image.
+        image_id: The ID of the built image.
     """
 
     image_name: str
     image_tag: str
+    image: str
+    image_id: str
 
 
 def build_docker_image(
     image_name: str,
     dockerfile: str = "Dockerfile",
     tag: Optional[str] = None,
-    push: bool = True,
+    push: bool = False,
     credentials: Optional[Dict] = None,
+    **build_kwargs,
 ) -> BuildDockerImageResult:
     """
     Builds a Docker image for a Prefect deployment.
@@ -48,12 +74,15 @@ def build_docker_image(
         push: Whether to push the built image to the registry.
         credentials: A dictionary containing the username, password, and URL for the
             registry to push the image to.
+        **build_kwargs: Additional keyword arguments to pass to Docker when building
+            the image. Available options can be found in the [`docker-py`](https://docker-py.readthedocs.io/en/stable/images.html#docker.models.images.ImageCollection.build)
+            documentation.
 
     Returns:
         A dictionary containing the image name and tag of the
             built image.
 
-    Examples:
+    Example:
         Build and push a Docker image prior to creating a deployment:
         ```yaml
         build:
@@ -61,9 +90,10 @@ def build_docker_image(
                 requires: prefect-docker
                 image_name: repo-name/image-name
                 tag: dev
+                push: true
         ```
 
-        Build a Docker image without pushing it to the registry:
+        Build a Docker image without pushing it to a remote registry:
         ```yaml
         build:
             - prefect_docker.projects.steps.build_docker_image:
@@ -73,7 +103,7 @@ def build_docker_image(
                 push: false
         ```
 
-        Build a Docker image using a temporary Dockerfile:
+        Build a Docker image using an auto-generated Dockerfile:
         ```yaml
         build:
             - prefect_docker.projects.steps.build_docker_image:
@@ -81,9 +111,10 @@ def build_docker_image(
                 image_name: repo-name/image-name
                 tag: dev
                 dockerfile: auto
+                push: false
         ```
 
-        Build a Docker image using a temporary Dockerfile and push it to a private
+        Build a Docker image using an auto-generated Dockerfile and push it to a private
         registry:
         ```yaml
         build:
@@ -92,7 +123,20 @@ def build_docker_image(
                 image_name: repo-name/image-name
                 tag: dev
                 dockerfile: auto
+                push: false
                 credentials: "{{ prefect.blocks.docker-registry-credentials.dev-registry }}"
+        ```
+
+        Build a Docker image for a different platform:
+        ```yaml
+        build:
+            - prefect_docker.projects.steps.build_docker_image:
+                requires: prefect-docker
+                image_name: repo-name/image-name
+                tag: dev
+                dockerfile: Dockerfile
+                push: false
+                platform: amd64
         ```
     """  # noqa
     auto_build = dockerfile == "auto"
@@ -100,13 +144,16 @@ def build_docker_image(
         lines = []
         base_image = get_prefect_image_name()
         lines.append(f"FROM {base_image}")
-
         dir_name = os.path.basename(os.getcwd())
-        lines.append(f"COPY . /opt/prefect/{dir_name}/")
-        lines.append(f"WORKDIR /opt/prefect/{dir_name}/")
 
         if Path("requirements.txt").exists():
+            lines.append(
+                f"COPY requirements.txt /opt/prefect/{dir_name}/requirements.txt"
+            )
             lines.append("RUN python -m pip install -r requirements.txt")
+
+        lines.append(f"COPY . /opt/prefect/{dir_name}/")
+        lines.append(f"WORKDIR /opt/prefect/{dir_name}/")
 
         temp_dockerfile = Path("Dockerfile")
         if Path(temp_dockerfile).exists():
@@ -117,21 +164,41 @@ def build_docker_image(
 
         dockerfile = str(temp_dockerfile)
 
-    try:
-        image_id = build_image(
-            context=Path("."),
-            dockerfile=dockerfile,
-            pull=True,
-            stream_progress_to=sys.stdout,
-        )
-    finally:
-        if auto_build:
-            os.unlink(dockerfile)
-
-    if not tag:
-        tag = slugify(pendulum.now("utc").isoformat())
+    build_kwargs["path"] = os.getcwd()
+    build_kwargs["dockerfile"] = dockerfile
+    build_kwargs["pull"] = build_kwargs.get("pull", True)
+    build_kwargs["decode"] = True
+    build_kwargs["labels"] = {**build_kwargs.get("labels", {}), **IMAGE_LABELS}
+    image_id = None
 
     with docker_client() as client:
+        try:
+            events = client.api.build(**build_kwargs)
+
+            try:
+                for event in events:
+                    if "stream" in event:
+                        sys.stdout.write(event["stream"])
+                        sys.stdout.flush()
+                    elif "aux" in event:
+                        image_id = event["aux"]["ID"]
+                    elif "error" in event:
+                        raise BuildError(event["error"])
+                    elif "message" in event:
+                        raise BuildError(event["message"])
+            except docker.errors.APIError as e:
+                raise BuildError(e.explanation) from e
+
+        finally:
+            if auto_build:
+                os.unlink(dockerfile)
+
+        if not isinstance(image_id, str):
+            raise BuildError("Docker did not return an image ID for built image.")
+
+        if not tag:
+            tag = slugify(pendulum.now("utc").isoformat())
+
         if credentials is not None:
             client.login(
                 username=credentials.get("username"),
@@ -159,4 +226,9 @@ def build_docker_image(
             finally:
                 client.api.remove_image(image=f"{image_name}:{tag}", noprune=True)
 
-    return {"image_name": f"{image_name}:{tag}", "image_tag": tag}
+    return {
+        "image_name": image_name,
+        "image_tag": tag,
+        "image": f"{image_name}:{tag}",
+        "image_id": image_id,
+    }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 prefect>=2.10.5
 docker>=6.0.0
+urllib3<2


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to prefect-docker 🎉!

We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Run `pre-commit install && pre-commit run --all` for linting.

Happy engineering!
-->

<!-- Include an overview here -->

- Adds the ability to pass build kwargs into `build_docker_image` to handle currently unsupported options like `platform`
- Puts `requirements.txt` copy at the beginning of the auto-generated Dockerfile to improve image layer caching
- Adds `image_id` and `image` to output. `image` has the same contents as the current `image_name`.
- `image_name` is updated to contain **only** the image name without the tag. This will be a breaking change.

<!-- Link to issue -->
Closes PrefectHQ/prefect#12943 
Closes PrefectHQ/prefect#12941 

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "Closes #<ISSUE_NUMBER>"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-docker/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-docker/blob/main/CHANGELOG.md)
