### PR TITLE
Emit event when docker container creation fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## 0.2.3
+
+Released May ??th, 2023.
+
+### Added
+
+- Emit a Prefect event when creation of a docker container fails.
+
 ## 0.2.2
 
 Released April 20th, 2023.

--- a/prefect_docker/worker.py
+++ b/prefect_docker/worker.py
@@ -551,7 +551,11 @@ class DockerWorker(BaseWorker):
             self._logger.info(f"Pulling image {configuration.image!r}...")
             self._pull_image(docker_client, configuration)
 
-        container = self._create_container(docker_client, **container_settings)
+        try:
+            container = self._create_container(docker_client, **container_settings)
+        except Exception as exc:
+            self._emit_container_creation_failed_event(configuration)
+            raise exc
 
         created_event = self._emit_container_status_change_event(
             container, configuration
@@ -731,6 +735,16 @@ class DockerWorker(BaseWorker):
             "prefect.resource.name": container.name,
         }
 
+    def _emit_container_creation_failed_event(
+        self, configuration: DockerWorkerJobConfiguration
+    ) -> Event:
+        """Emit a Prefect event when a docker container fails to be created."""
+        return emit_event(
+            event="prefect.docker.container.creation-failed",
+            resource=self._event_resource(),
+            related=self._event_related_resources(configuration=configuration),
+        )
+
     def _emit_container_status_change_event(
         self,
         container: "Container",
@@ -738,8 +752,6 @@ class DockerWorker(BaseWorker):
         last_event: Optional[Event] = None,
     ) -> Event:
         """Emit a Prefect event for a Docker container event."""
-        resource = self._container_as_resource(container)
-
         related = self._event_related_resources(configuration=configuration)
 
         worker_resource = self._event_resource()
@@ -748,7 +760,7 @@ class DockerWorker(BaseWorker):
 
         return emit_event(
             event=f"prefect.docker.container.{container.status.lower()}",
-            resource=resource,
+            resource=self._container_as_resource(container),
             related=related + [worker_related_resource],
             follows=last_event,
         )


### PR DESCRIPTION
This updates the worker to emit an event when creation of a docker container fails.

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request includes tests or only affects documentation.
- [x] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-docker/blob/main/CHANGELOG.md)
