### PR TITLE
Adds `push_docker_image` step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Emit a Prefect event when creation of a docker container fails.
+- Emit a Prefect event when creation of a docker container fails - [#50](https://github.com/PrefectHQ/prefect-docker/pull/50)
 - Ability to pass build kwargs into `build_docker_image` - [#51](https://github.com/PrefectHQ/prefect-docker/pull/51)
 - `image_id` and `image` to `build_docker_image` output. image has the same contents as the current `image_name` - [#51](https://github.com/PrefectHQ/prefect-docker/pull/51)
 - `push_docker_image` step - [#64](https://github.com/PrefectHQ/prefect-docker/pull/64)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Emit a Prefect event when creation of a docker container fails.
 - Ability to pass build kwargs into `build_docker_image` - [#51](https://github.com/PrefectHQ/prefect-docker/pull/51)
 - `image_id` and `image` to `build_docker_image` output. image has the same contents as the current `image_name` - [#51](https://github.com/PrefectHQ/prefect-docker/pull/51)
+- `push_docker_image` step - [#64](https://github.com/PrefectHQ/prefect-docker/pull/64)
 
 ### Changed
 
@@ -19,20 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - `prefect_docker.projects` module. Use `prefect_docker.deployments` instead. - [#63](https://github.com/PrefectHQ/prefect-docker/pull/63)
+- `push` on `build_docker_image`. Use `push_docker_image` instead. - [#64](https://github.com/PrefectHQ/prefect-docker/pull/64)
 
 ### Removed
 
 ### Fixed
 
 ### Security
-
-## 0.2.3
-
-Released May ??th, 2023.
-
-### Added
-
-- Emit a Prefect event when creation of a docker container fails.
 
 ## 0.2.2
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to prefect-docker 🎉!

We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Run `pre-commit install && pre-commit run --all` for linting.

Happy engineering!
-->

<!-- Include an overview here -->
## Adds `push_docker_image` Function

This PR adds a new `push_docker_image` step which can be used as a replacement to the `push` attribute on the `build_docker_image` step. The `push` attribute on the `build_docker_image` step is also deprecated as part of this PR.
<!-- Link to issue -->
Closes #54

### Example

Here's an example of how the new function can be used:

```python
push_docker_image(
    image_name="registry/repo",
    tag="mytag",
    credentials={
        "username": "user",
        "password": "pass",
        "registry_url": "https://registry.com",
        "reauth": True,
    },
)
```

This code pushes a Docker image named registry/repo:mytag to the registry at https://registry.com. The reauth parameter is set to True to force re-authentication.
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "Closes #<ISSUE_NUMBER>"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-docker/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-docker/blob/main/CHANGELOG.md)
