### PR TITLE
keep dockerfile option

### DIFF
--- a/prefect_docker/deployments/steps.py
+++ b/prefect_docker/deployments/steps.py
@@ -86,6 +86,7 @@ def build_docker_image(
     tag: Optional[str] = None,
     push: bool = False,
     credentials: Optional[Dict] = None,
+    keep_dockerfile: bool = False,
     **build_kwargs,
 ) -> BuildDockerImageResult:
     """
@@ -196,7 +197,7 @@ def build_docker_image(
                 raise BuildError(e.explanation) from e
 
         finally:
-            if auto_build:
+            if auto_build and not keep_dockerfile:
                 os.unlink(dockerfile)
 
         if not isinstance(image_id, str):

--- a/prefect_docker/deployments/steps.py
+++ b/prefect_docker/deployments/steps.py
@@ -104,6 +104,8 @@ def build_docker_image(
         push: DEPRECATED: Whether to push the built image to the registry.
         credentials: A dictionary containing the username, password, and URL for the
             registry to push the image to.
+        keep_dockerfile: Whether to keep the Dockerfile created by setting
+            `dockerfile="auto"`.
         **build_kwargs: Additional keyword arguments to pass to Docker when building
             the image. Available options can be found in the [`docker-py`](https://docker-py.readthedocs.io/en/stable/images.html#docker.models.images.ImageCollection.build)
             documentation.
@@ -133,7 +135,6 @@ def build_docker_image(
                 push: false
         ```
 
-
         Build a Docker image for a different platform:
         ```yaml
         build:
@@ -144,6 +145,18 @@ def build_docker_image(
                 dockerfile: Dockerfile
                 push: false
                 platform: amd64
+        ```
+
+        Keep the Dockerfile created by setting `dockerfile="auto"`:
+        ```yaml
+        build:
+            - prefect_docker.deployments.steps.build_docker_image:
+                requires: prefect-docker
+                image_name: repo-name/image-name
+                tag: dev
+                dockerfile: Dockerfile
+                push: false
+                keep_dockerfile: true
         ```
     """  # noqa
     auto_build = dockerfile == "auto"


### PR DESCRIPTION
a couple users (from pacc) have proposed that something like a `keep_dockerfile` option to avoid cleaning up the Dockerfile would be helpful for debugging if something goes wrong with auto / to build off of / or just clarity into whats happening

### Example
```yaml
definitions:
    actions:
        docker_build: &docker_build
            - prefect_docker.projects.steps.build_docker_image: &docker_build_config
                id: build_image
                requires: prefect-docker>=0.2.0
                image_name: zzstoatzz/prefect-monorepo
                dockerfile: auto
                push: true
                keep_dockerfile: true
```

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] This pull request references any related issue by including "Closes #<ISSUE_NUMBER>"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-docker/issues/new/choose) first.
- [ ] This pull request includes tests or only affects documentation.
- [ ] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-docker/blob/main/CHANGELOG.md)
