### PR TITLE
TypeError: unsupported operand type(s) for +: 'generator' and 'generator'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-## 0.3.3
+## 0.4.3
+
+### Added
+- fix for multiple Docker tags
+
+## 0.4.2
 
 ### Added
 - allow multiple Docker tags for build and push steps

--- a/prefect_docker/deployments/steps.py
+++ b/prefect_docker/deployments/steps.py
@@ -134,10 +134,9 @@ def build_docker_image(
                 requires: prefect-docker
                 image_name: repo-name/image-name
                 tag: dev
-                additional_tags: [
-                    v0.1.0,
-                    dac9ccccedaa55a17916eef14f95cc7bdd3c8199
-                ]
+                additional_tags:
+                    - v0.1.0,
+                    - dac9ccccedaa55a17916eef14f95cc7bdd3c8199
         ```
 
         Build a Docker image using an auto-generated Dockerfile:

--- a/prefect_docker/deployments/steps.py
+++ b/prefect_docker/deployments/steps.py
@@ -336,13 +336,15 @@ def push_docker_image(
                 registry=credentials.get("registry_url"),
                 reauth=credentials.get("reauth", True),
             )
-        events = client.api.push(
-            repository=image_name, tag=tag, stream=True, decode=True
+        events = list(
+            client.api.push(repository=image_name, tag=tag, stream=True, decode=True)
         )
         additional_tags = additional_tags or []
         for i, tag_ in enumerate(additional_tags):
-            event = client.api.push(
-                repository=image_name, tag=tag_, stream=True, decode=True
+            event = list(
+                client.api.push(
+                    repository=image_name, tag=tag_, stream=True, decode=True
+                )
             )
             events = events + event
 

--- a/tests/deployments/test_steps.py
+++ b/tests/deployments/test_steps.py
@@ -269,7 +269,14 @@ def test_push_docker_image_with_additional_tags(mock_docker_client, monkeypatch)
     mock_stdout = MagicMock()
     monkeypatch.setattr(sys, "stdout", mock_stdout)
 
-    mock_docker_client.api.push.return_value = FAKE_EVENT
+    # client.api.push can return a generator or strings; here we test with a generator
+    # we end up calling client.api.push 3 times in this test (once for tag, twice for
+    # additional_tags), therefore we need the mocked push to return 3 generators
+    mock_docker_client.api.push.side_effect = [
+        (e for e in FAKE_EVENT),
+        (e for e in FAKE_EVENT),
+        (e for e in FAKE_EVENT),
+    ]
 
     result = push_docker_image(
         image_name=FAKE_IMAGE_NAME,


### PR DESCRIPTION
Closes #100 

Reviewing by commit is helpful:
* 41e024d1feb3842f946e8c9e1e1b2f608912c6f2 update unit tests in order to reproduce bug
* d8f6147e71f7e295fa67a3af16204941ecde76ec implement fix (which fixes broken unit test too)

![image](https://github.com/PrefectHQ/prefect-docker/assets/8518288/6eccff64-47d8-4a4c-8ce4-4f7981ff1cde)


### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "Closes #<ISSUE_NUMBER>"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-docker/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-docker/blob/main/CHANGELOG.md)
