### PR TITLE
Adds registry credentials to Docker worker configuration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,8 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
+          - "3.12"
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,4 +34,4 @@ jobs:
         env:
           PREFECT_API_DATABASE_CONNECTION_URL: "sqlite+aiosqlite:///./prefect-tests.db"
         run: |
-          pytest tests -vvv --numprocesses 4 --dist loadscope --cov=prefect_docker/ --cov=tests/ --no-cov-on-fail
+          pytest tests -vvv --numprocesses auto --dist loadscope --cov=prefect_docker/ --cov=tests/ --no-cov-on-fail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,15 +19,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## 0.4.4
+
+Released January 23rd, 2023.
+
+- Adds registry credentials support to Docker worker - [#102](https://github.com/PrefectHQ/prefect-docker/pull/102)
+
 ## 0.4.3
 
 ### Added
-- fix for multiple Docker tags
+
+Released January 10th, 2023.
+
+- Fix for multiple Docker tags - [#101](https://github.com/PrefectHQ/prefect-docker/pull/101)
 
 ## 0.4.2
 
 ### Added
-- allow multiple Docker tags for build and push steps
+
+Released January 8th, 2023.
+
+- Allow multiple Docker tags for build and push steps - [#97](https://github.com/PrefectHQ/prefect-docker/pull/97)
 
 ## 0.3.2
 

--- a/prefect_docker/credentials.py
+++ b/prefect_docker/credentials.py
@@ -46,7 +46,7 @@ class DockerRegistryCredentials(Block):
         description=(
             'The URL to the registry. Generally, "http" or "https" can be omitted.'
         ),
-        example="registry.hub.docker.com",
+        example="index.docker.io",
     )
     reauth: bool = Field(
         default=True,

--- a/prefect_docker/worker.py
+++ b/prefect_docker/worker.py
@@ -544,7 +544,13 @@ class DockerWorker(BaseWorker):
         """Creates and starts a Docker container."""
         docker_client = self._get_client()
         if configuration.registry_credentials:
-            configuration.registry_credentials.login(docker_client)
+            self._logger.info("Logging into Docker registry...")
+            docker_client.login(
+                username=configuration.registry_credentials.username,
+                password=configuration.registry_credentials.password.get_secret_value(),
+                registry=configuration.registry_credentials.registry_url,
+                reauth=configuration.registry_credentials.reauth,
+            )
         container_settings = self._build_container_settings(
             docker_client, configuration
         )

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -112,13 +112,13 @@ def flow_run():
 
 
 @pytest.fixture
-def registry_credentials():
+async def registry_credentials():
     block = DockerRegistryCredentials(
         username="my_username",
         password="my_password",
         registry_url="registry.hub.docker.com",
     )
-    block.save(name="test", overwrite=True)
+    await block.save(name="test", overwrite=True)
     return block
 
 


### PR DESCRIPTION
<!-- 
Thanks for opening a pull request to prefect-docker 🎉!

We've got a few requests to help us review contributions:

- Make sure that your title neatly summarizes the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share an example to help us understand the change in user experience.
- Run `pre-commit install && pre-commit run --all` for linting.

Happy engineering!
-->

<!-- Include an overview here -->
Adds the ability to define Docker registry credentials to use for authentication when pulling images. Credentials can be set at the work pool level or set at the deployment level via `job_variables`.

<!-- Link to issue -->
Closes #72

### Example
<!-- 
Share an example of the change in action.

A code blurb is best. Changes to features should include an example that is executable by a new user.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] This pull request references any related issue by including "Closes #<ISSUE_NUMBER>"
	- If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-docker/issues/new/choose) first.
- [x] This pull request includes tests or only affects documentation.
- [x] Summarized PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-docker/blob/main/CHANGELOG.md)
